### PR TITLE
Feature/17636 add configuration for new monitoring stack

### DIFF
--- a/initialization/CHANGELOG.md
+++ b/initialization/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.1.0
+
+Released: September 14th, 2021
+
+Add some configurations to support the new monitoring stack:
+- A new key/value pair in the Secrets for Redis and Redis Persistent clusters
+- A monitoring user to read metrics from MongoDB
+
+---
+
 # 2.0.0
 Released: October 2nd, 2020
 

--- a/initialization/src/entrypoints/generate.ts
+++ b/initialization/src/entrypoints/generate.ts
@@ -9,7 +9,8 @@ import {
 	writeSecret,
 	createSingleDatabaseScriptSnippet,
 	writeDatabaseInitialization,
-	generateSecretsFolder
+	generateSecretsFolder,
+	createClusterMonitorScriptSnippet
 } from "../utils";
 import { ISecret } from "../interfaces/secret";
 
@@ -33,7 +34,13 @@ export function generateFiles() {
 			}
 
 			if (serviceName && dbPassword) {
-				dbCreationScript += createSingleDatabaseScriptSnippet(serviceName, dbPassword);
+				/** Add a user for MongoDB exporter */
+				if (serviceName === "mongodb-exporter") {
+					dbCreationScript += createClusterMonitorScriptSnippet(serviceName, dbPassword);
+				}
+				else {
+					dbCreationScript += createSingleDatabaseScriptSnippet(serviceName, dbPassword);
+				}
 			}
 		}
 

--- a/initialization/src/interfaces/secret.ts
+++ b/initialization/src/interfaces/secret.ts
@@ -12,6 +12,8 @@ export interface ISecret {
 		'tls.crt'?: string;
 		'tls.key'?: string;
 		'redis-persistent-password.conf'?: string;
+		'REDIS_PERSISTENT_PASSWORD'?: string;
+		'REDIS_PASSWORD'?: string;
 		'redis-password.conf'?: string;
 		'amazon-client-id'?: string;
 		'amazon-client-secret'?: string;

--- a/initialization/src/utils.ts
+++ b/initialization/src/utils.ts
@@ -177,24 +177,28 @@ export function fillSecret(secret: ISecret): ISecretWrapper {
 	}
 
 	if (data['redis-password.conf'] !== undefined) {
+		const redisPassword = createCompactSecret()
 		return {
 			secret: {
 				...secret,
 				data: {
 					...data,
-					'redis-password.conf': toBase64(`requirepass ${createCompactSecret()}`)
+					'redis-password.conf': toBase64(`requirepass ${redisPassword}`),
+					'REDIS_PASSWORD': toBase64(redisPassword)
 				}
 			}
 		};
 	}
 
 	if (data['redis-persistent-password.conf'] !== undefined) {
+		const redisPersistentPassword = createCompactSecret()
 		return {
 			secret: {
 				...secret,
 				data: {
 					...data,
-					'redis-persistent-password.conf': toBase64(`requirepass ${createCompactSecret()}`)
+					'redis-persistent-password.conf': toBase64(`requirepass ${redisPersistentPassword}`),
+					'REDIS_PERSISTENT_PASSWORD': toBase64(redisPersistentPassword)
 				}
 			}
 		};


### PR DESCRIPTION
The new monitoring stack requires two update:
- A new key-value pair for redis and redis-persistent Secrets
- A MongoDB user which has the monitor role, being used by the MongoDB exporter